### PR TITLE
Fixed Language Reference

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -536,7 +536,7 @@ function DamageHashCheck(damageHash)
     elseif Knives[hash] then
         damageType = _U('cut')
     elseif Blunt[hash] then
-        damageType = _U('bruised')
+        damageType = _U('bruise')
     elseif Guns[hash] then
         damageType = _U('shot')
     else


### PR DESCRIPTION
Small Change, but wanted to bring it to your attention.

When Punched, it is looking for translation 'bruised' on Line 540 of client.lua. In the language file it is listed as bruise. This fixes line 540 to correctly reference that language.  